### PR TITLE
Add reminder SMS summary report

### DIFF
--- a/packages/behin-simple-workflow-report/src/Controllers/Core/DailyReportReminderSummaryController.php
+++ b/packages/behin-simple-workflow-report/src/Controllers/Core/DailyReportReminderSummaryController.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Behin\SimpleWorkflowReport\Controllers\Core;
+
+use App\Http\Controllers\Controller;
+use Behin\SimpleWorkflowReport\Models\DailyReportReminderLog;
+use Behin\SimpleWorkflowReport\Services\DailyReportReminderService;
+use BehinUserRoles\Models\User;
+use Carbon\Carbon;
+use Illuminate\Contracts\View\View;
+use Illuminate\Http\Request;
+use Illuminate\Support\Collection;
+use Morilog\Jalali\Jalalian;
+
+class DailyReportReminderSummaryController extends Controller
+{
+    public function __construct(private DailyReportReminderService $reminderService)
+    {
+    }
+
+    public function index(Request $request): View
+    {
+        $defaultFrom = Jalalian::now()->format('Y-m-d');
+        $fromInput = convertPersianToEnglish($request->input('from_date', $defaultFrom));
+        $toSource = $request->input('to_date', $request->input('from_date', $defaultFrom));
+        $toInput = convertPersianToEnglish($toSource);
+
+        $from = Jalalian::fromFormat('Y-m-d', $fromInput)->toCarbon()->startOfDay();
+        $to = Jalalian::fromFormat('Y-m-d', $toInput)->toCarbon()->endOfDay();
+
+        $allUsers = User::query()->orderBy('number', 'asc')->get();
+
+        $users = $allUsers;
+        if ($request->filled('user_id')) {
+            $users = $allUsers
+                ->where('id', (int) $request->input('user_id'))
+                ->values();
+        }
+
+        $reminderLogs = $this->reminderService->getReminderLogs($from, $to, $request->integer('user_id'))
+            ->groupBy('user_id');
+
+        $uniqueDates = $reminderLogs
+            ->flatMap(function (Collection $logs) {
+                return $logs->pluck('report_date');
+            })
+            ->unique();
+
+        $reportingUsersByDate = $uniqueDates->isEmpty()
+            ? collect()
+            : $this->reminderService->getReportingUsersByDate($uniqueDates);
+
+        $users->each(function (User $user) use ($reminderLogs, $reportingUsersByDate) {
+            /** @var Collection<int, DailyReportReminderLog> $logs */
+            $logs = $reminderLogs->get($user->id, collect());
+            $user->reminder_count = $logs->count();
+
+            $userId = (int) $user->id;
+            $user->missing_report_count = $logs->filter(function (DailyReportReminderLog $log) use ($reportingUsersByDate, $userId) {
+                $dateString = Carbon::parse($log->report_date)->toDateString();
+                $reportingUsers = $reportingUsersByDate->get($dateString, collect());
+
+                return ! $reportingUsers->contains($userId);
+            })->count();
+        });
+
+        $fromDate = Jalalian::fromCarbon($from)->format('Y-m-d');
+        $toDate = Jalalian::fromCarbon($to)->format('Y-m-d');
+
+        return view('SimpleWorkflowReportView::Core.DailyReportReminder.index', [
+            'users' => $users,
+            'allUsers' => $allUsers,
+            'fromDate' => $fromDate,
+            'toDate' => $toDate,
+            'selectedUserId' => $request->input('user_id'),
+        ]);
+    }
+}

--- a/packages/behin-simple-workflow-report/src/Routes/web.php
+++ b/packages/behin-simple-workflow-report/src/Routes/web.php
@@ -23,6 +23,7 @@ use Behin\SimpleWorkflowReport\Controllers\Core\TimeoffController;
 use Behin\SimpleWorkflowReport\Controllers\Core\CounterPartyController;
 use Behin\SimpleWorkflowReport\Controllers\Core\CreditorReportController;
 use Behin\SimpleWorkflowReport\Controllers\Core\DailyReportController;
+use Behin\SimpleWorkflowReport\Controllers\Core\DailyReportReminderSummaryController;
 use Behin\SimpleWorkflowReport\Controllers\Core\OnCreditReportController;
 use Behin\SimpleWorkflowReport\Controllers\Core\PersonelActivityController;
 use Behin\SimpleWorkflowReport\Controllers\Core\PettyCashController;
@@ -91,6 +92,8 @@ Route::name('simpleWorkflowReport.')->prefix('workflow-report')->middleware(['we
     Route::get('personel-activity/{user_id}/show-dones/{from?}/{to?}', [PersonelActivityController::class, 'showDones'])->name('personel-activity.showDones');
 
     Route::get('daily-report', [DailyReportController:: class, 'index'])->name('daily-report.index');
+    Route::get('daily-report/reminder-summary', [DailyReportReminderSummaryController::class, 'index'])
+        ->name('daily-report.reminder-summary');
     Route::get('daily-report/{user_id}/show-internal/{from?}/{to?}', [DailyReportController:: class, 'showInternal'])->name('daily-report.show-internal');
     Route::get('daily-report/{user_id}/show-external/{from?}/{to?}', [DailyReportController:: class, 'showExternal'])->name('daily-report.show-external');
     Route::get('daily-report/{user_id}/show-mapa-center/{from?}/{to?}', [DailyReportController:: class, 'showMapaCenter'])->name('daily-report.show-mapa-center');

--- a/packages/behin-simple-workflow-report/src/Services/DailyReportReminderService.php
+++ b/packages/behin-simple-workflow-report/src/Services/DailyReportReminderService.php
@@ -1,0 +1,175 @@
+<?php
+
+namespace Behin\SimpleWorkflowReport\Services;
+
+use Behin\SimpleWorkflow\Models\Entities\Mapa_center_fix_report;
+use Behin\SimpleWorkflow\Models\Entities\Other_daily_reports;
+use Behin\SimpleWorkflow\Models\Entities\Part_reports;
+use Behin\SimpleWorkflow\Models\Entities\Repair_reports;
+use Behin\SimpleWorkflowReport\Models\DailyReportReminderLog;
+use Carbon\Carbon;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
+use Throwable;
+
+class DailyReportReminderService
+{
+    /**
+     * Retrieve all user identifiers that have registered any type of daily report on the given date.
+     */
+    public function getUsersWithReports(Carbon $date): Collection
+    {
+        $dateString = $date->toDateString();
+
+        $reportingUsers = collect();
+
+        $reportingUsers = $reportingUsers->merge(
+            Part_reports::query()->whereDate('updated_at', $dateString)->pluck('registered_by')
+        );
+
+        $externalReports = Repair_reports::query()
+            ->whereDate('created_at', $dateString)
+            ->get(['mapa_expert', 'mapa_expert_companions']);
+
+        $reportingUsers = $reportingUsers->merge(
+            $externalReports->pluck('mapa_expert')->filter()
+        );
+
+        $assistantUsers = $externalReports->pluck('mapa_expert_companions')
+            ->filter()
+            ->flatMap(function ($companions) {
+                return $this->extractCompanionIds($companions);
+            });
+
+        $reportingUsers = $reportingUsers->merge($assistantUsers);
+
+        $reportingUsers = $reportingUsers->merge(
+            Mapa_center_fix_report::query()->whereDate('updated_at', $dateString)->pluck('expert')
+        );
+
+        $reportingUsers = $reportingUsers->merge(
+            $this->getOtherDailyReportUserIds($date)
+        );
+
+        return $reportingUsers
+            ->filter()
+            ->map(function ($id) {
+                return (int) $id;
+            })
+            ->unique()
+            ->values();
+    }
+
+    /**
+     * Determine how many reminder SMS logs (with sent status) exist for each user within the given period.
+     */
+    public function getReminderLogs(Carbon $from, Carbon $to, ?int $userId = null): Collection
+    {
+        $query = DailyReportReminderLog::query()
+            ->where('status', DailyReportReminderLog::STATUS_SENT)
+            ->whereBetween('report_date', [
+                $from->toDateString(),
+                $to->toDateString(),
+            ]);
+
+        if ($userId) {
+            $query->where('user_id', $userId);
+        }
+
+        return $query->orderBy('report_date')->get();
+    }
+
+    /**
+     * Build a map of date string => collection of user IDs that have registered a report on that date.
+     */
+    public function getReportingUsersByDate(Collection $dates): Collection
+    {
+        $dates = $dates
+            ->map(function ($date) {
+                if ($date instanceof Carbon) {
+                    return $date->copy()->startOfDay();
+                }
+
+                return Carbon::parse($date)->startOfDay();
+            })
+            ->unique(function (Carbon $date) {
+                return $date->toDateString();
+            })
+            ->values();
+
+        return $dates->mapWithKeys(function (Carbon $date) {
+            return [
+                $date->toDateString() => $this->getUsersWithReports($date),
+            ];
+        });
+    }
+
+    private function extractCompanionIds($companions): array
+    {
+        if ($companions instanceof Collection) {
+            $companions = $companions->all();
+        }
+
+        if (is_array($companions)) {
+            return $this->normalizeCompanionValues($companions);
+        }
+
+        if (is_string($companions)) {
+            $decoded = json_decode($companions, true);
+            if (json_last_error() === JSON_ERROR_NONE && is_array($decoded)) {
+                return $this->normalizeCompanionValues($decoded);
+            }
+
+            $cleaned = str_replace(['[', ']', '"', "'"], '', $companions);
+            $parts = preg_split('/[\\s,]+/', $cleaned);
+
+            return $this->normalizeCompanionValues($parts ?: []);
+        }
+
+        return [];
+    }
+
+    private function normalizeCompanionValues(array $values): array
+    {
+        return collect($values)
+            ->map(function ($value) {
+                if (is_array($value) && array_key_exists('id', $value)) {
+                    return $value['id'];
+                }
+
+                if (is_object($value) && isset($value->id)) {
+                    return $value->id;
+                }
+
+                return $value;
+            })
+            ->filter(function ($value) {
+                return is_numeric($value);
+            })
+            ->map(function ($value) {
+                return (int) $value;
+            })
+            ->unique()
+            ->values()
+            ->all();
+    }
+
+    private function getOtherDailyReportUserIds(Carbon $date): Collection
+    {
+        $dateString = $date->toDateString();
+
+        try {
+            return Other_daily_reports::query()
+                ->whereDate('created_at', $dateString)
+                ->pluck('created_by');
+        } catch (Throwable $exception) {
+            try {
+                return DB::table('wf_entity_other_daily_reports')
+                    ->whereDate('created_at', $dateString)
+                    ->pluck('created_by');
+            } catch (Throwable $innerException) {
+                return collect();
+            }
+        }
+    }
+}

--- a/packages/behin-simple-workflow-report/src/Views/Core/DailyReportReminder/index.blade.php
+++ b/packages/behin-simple-workflow-report/src/Views/Core/DailyReportReminder/index.blade.php
@@ -1,0 +1,77 @@
+@extends('behin-layouts.app')
+
+@section('title', 'گزارش پیامک یادآوری گزارش روزانه')
+
+@section('content')
+    <div class="container">
+        <div class="card">
+            <div class="card-header rounded shadow-sm p-4 mb-4" style="background-color: #e8f6f3;">
+                <form method="GET" action="{{ route('simpleWorkflowReport.daily-report.reminder-summary') }}">
+                    <div class="row g-3 align-items-end">
+                        <div class="col-md-3">
+                            <label for="from_date" class="form-label fw-bold">از تاریخ</label>
+                            <input type="text" id="from_date" name="from_date"
+                                   class="form-control persian-date rounded-pill shadow-sm" value="{{ $fromDate }}"
+                                   placeholder="مثلاً 1403/01/01">
+                        </div>
+                        <div class="col-md-3">
+                            <label for="to_date" class="form-label fw-bold">تا تاریخ</label>
+                            <input type="text" id="to_date" name="to_date"
+                                   class="form-control persian-date rounded-pill shadow-sm" value="{{ $toDate }}"
+                                   placeholder="مثلاً 1403/01/31">
+                        </div>
+                        <div class="col-md-3">
+                            <label for="user_id" class="form-label fw-bold">پرسنل</label>
+                            <select name="user_id" id="user_id" class="form-control select2 rounded-pill shadow-sm">
+                                <option value="">همه پرسنل</option>
+                                @foreach ($allUsers as $user)
+                                    <option value="{{ $user->id }}" {{ (string) $selectedUserId === (string) $user->id ? 'selected' : '' }}>
+                                        {{ $user->name }}
+                                    </option>
+                                @endforeach
+                            </select>
+                        </div>
+                        <div class="col-md-3 d-grid">
+                            <button type="submit" class="btn btn-success rounded-pill shadow-sm fw-bold">فیلتر</button>
+                        </div>
+                    </div>
+                </form>
+            </div>
+
+            <div class="card-body">
+                <div class="table-responsive">
+                    <table class="table table-hover">
+                        <thead style="background-color: #b8e0d2; color: #1d2d2c;">
+                        <tr>
+                            <th>شماره</th>
+                            <th>نام</th>
+                            <th>تعداد پیامک یادآوری ارسال شده</th>
+                            <th>تعداد روزهای بدون گزارش پس از یادآوری</th>
+                        </tr>
+                        </thead>
+                        <tbody>
+                        @forelse ($users as $user)
+                            <tr>
+                                <td>{{ $user->number }}</td>
+                                <td>{{ $user->name }}</td>
+                                <td>{{ $user->reminder_count ?? 0 }}</td>
+                                <td>{{ $user->missing_report_count ?? 0 }}</td>
+                            </tr>
+                        @empty
+                            <tr>
+                                <td colspan="4" class="text-center">رکوردی یافت نشد.</td>
+                            </tr>
+                        @endforelse
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+        </div>
+    </div>
+@endsection
+
+@section('script')
+    <script>
+        initial_view();
+    </script>
+@endsection


### PR DESCRIPTION
## Summary
- extract daily report reminder helpers into a dedicated service
- add a reminder summary controller and Blade view with filtering by date and user
- register the new route and update the daily report controller to reuse the shared service

## Testing
- php -l packages/behin-simple-workflow-report/src/Controllers/Core/DailyReportReminderSummaryController.php
- php -l packages/behin-simple-workflow-report/src/Services/DailyReportReminderService.php
- php -l packages/behin-simple-workflow-report/src/Controllers/Core/DailyReportController.php


------
https://chatgpt.com/codex/tasks/task_e_68e11d46f5d48332a640882f8622c53b