### PR TITLE
Skip sending daily report reminders on Fridays

### DIFF
--- a/packages/behin-simple-workflow-report/src/Controllers/Core/DailyReportController.php
+++ b/packages/behin-simple-workflow-report/src/Controllers/Core/DailyReportController.php
@@ -278,6 +278,13 @@ class DailyReportController extends Controller
             $targetDate = Carbon::today();
         }
 
+        if ($targetDate->isFriday()) {
+            return response()->json([
+                'status' => 'skipped',
+                'message' => 'ارسال پیامک یادآوری در روز جمعه انجام نمی‌شود.',
+            ]);
+        }
+
         $templateId = config('services.sms.daily_report_reminder_template_id');
         if (! $templateId) {
             return response()->json([


### PR DESCRIPTION
## Summary
- prevent the daily report reminder endpoint from running on Fridays
- return a skipped response message when the reminder date is Friday

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e129ec97a48332810c5942810a126e