### PR TITLE
feat: link users with counter parties

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -4,6 +4,7 @@ namespace App\Models;
 
 // use Illuminate\Contracts\Auth\MustVerifyEmail;
 
+use Behin\SimpleWorkflow\Models\Entities\Counter_parties;
 use BehinInit\App\Http\Controllers\AccessController;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
@@ -48,5 +49,10 @@ class User extends Authenticatable
     }
     function access($method_name) {
         return (new AccessController($method_name))->check();
+    }
+
+    public function counterParties()
+    {
+        return $this->hasMany(Counter_parties::class, 'user_id');
     }
 }

--- a/database/migrations/2025_10_29_000001_add_user_id_to_wf_entity_counter_parties_table.php
+++ b/database/migrations/2025_10_29_000001_add_user_id_to_wf_entity_counter_parties_table.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::table('wf_entity_counter_parties', function (Blueprint $table) {
+            $table->unsignedBigInteger('user_id')->nullable()->after('state');
+            $table->foreign('user_id')->references('id')->on('users')->nullOnDelete();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('wf_entity_counter_parties', function (Blueprint $table) {
+            $table->dropForeign(['user_id']);
+            $table->dropColumn('user_id');
+        });
+    }
+};

--- a/packages/behin-simple-workflow-report/src/Controllers/Core/CounterPartyController.php
+++ b/packages/behin-simple-workflow-report/src/Controllers/Core/CounterPartyController.php
@@ -15,6 +15,7 @@ use Behin\SimpleWorkflow\Models\Core\Process;
 use Behin\SimpleWorkflow\Models\Core\TaskActor;
 use Behin\SimpleWorkflow\Models\Core\Variable;
 use Behin\SimpleWorkflow\Models\Entities\Counter_parties;
+use BehinUserRoles\Models\User;
 use Behin\SimpleWorkflow\Models\Entities\Devices;
 use Behin\SimpleWorkflow\Models\Entities\Financials;
 use Behin\SimpleWorkflow\Models\Entities\Parts;
@@ -30,7 +31,7 @@ class CounterPartyController extends Controller
 {
     public function index(Request $request)
     {
-        $counterParties = Counter_parties::all();
+        $counterParties = Counter_parties::with('user')->orderBy('name')->get();
         return view('SimpleWorkflowReportView::Core.CounterParty.index', compact('counterParties'));
     }
 
@@ -45,12 +46,21 @@ class CounterPartyController extends Controller
 
     public function create()
     {
-        return view('SimpleWorkflowReportView::Core.CounterParty.create');
+        $users = User::orderBy('name')->get();
+        return view('SimpleWorkflowReportView::Core.CounterParty.create', compact('users'));
     }
 
     public function store(Request $request)
     {
-        $counterParty = Counter_parties::create($request->all());
+        $validated = $request->validate([
+            'name' => ['required', 'string', 'max:255'],
+            'account_number' => ['nullable', 'string', 'max:255'],
+            'user_id' => ['nullable', 'integer', 'exists:users,id'],
+            'description' => ['nullable', 'string'],
+            'state' => ['nullable', 'string', 'max:255'],
+        ]);
+
+        Counter_parties::create($validated);
         return redirect()->route('simpleWorkflowReport.counter-party.index');
     }
 

--- a/packages/behin-simple-workflow-report/src/Views/Core/CounterParty/create.blade.php
+++ b/packages/behin-simple-workflow-report/src/Views/Core/CounterParty/create.blade.php
@@ -8,18 +8,45 @@
                 <form action="{{ route('simpleWorkflowReport.counter-party.store') }}" method="POST">
                     @csrf
                     <div class="row">
-                        <div class="col-md-6">
+                        <div class="col-md-4">
                             <div class="form-group">
                                 <label for="name">نام</label>
-                                <input type="text" name="name" id="name" class="form-control" autofocus focus>
+                                <input type="text" name="name" id="name" class="form-control" autofocus focus value="{{ old('name') }}">
+                                @error('name')
+                                    <span class="text-danger">{{ $message }}</span>
+                                @enderror
                             </div>
                         </div>
-                        <div class="col-md-6">
+                        <div class="col-md-4">
                             <div class="form-group">
                                 <label for="account_number">شماره حساب</label>
-                                <input type="text" name="account_number" id="account_number" class="form-control">
+                                <input type="text" name="account_number" id="account_number" class="form-control" value="{{ old('account_number') }}">
+                                @error('account_number')
+                                    <span class="text-danger">{{ $message }}</span>
+                                @enderror
                             </div>
                         </div>
+                        <div class="col-md-4">
+                            <div class="form-group">
+                                <label for="user_id">کاربر مرتبط</label>
+                                <select name="user_id" id="user_id" class="form-control">
+                                    <option value="">-</option>
+                                    @foreach ($users as $user)
+                                        <option value="{{ $user->id }}" {{ old('user_id') == $user->id ? 'selected' : '' }}>{{ $user->name }} ({{ $user->email }})</option>
+                                    @endforeach
+                                </select>
+                                @error('user_id')
+                                    <span class="text-danger">{{ $message }}</span>
+                                @enderror
+                            </div>
+                        </div>
+                    </div>
+                    <div class="form-group">
+                        <label for="description">توضیحات</label>
+                        <textarea name="description" id="description" class="form-control" rows="3">{{ old('description') }}</textarea>
+                        @error('description')
+                            <span class="text-danger">{{ $message }}</span>
+                        @enderror
                     </div>
                     <button type="submit" class="btn btn-primary">ایجاد</button>
                 </form>

--- a/packages/behin-simple-workflow-report/src/Views/Core/CounterParty/index.blade.php
+++ b/packages/behin-simple-workflow-report/src/Views/Core/CounterParty/index.blade.php
@@ -20,6 +20,7 @@
                             <th>#</th>
                             <th>نام</th>
                             <th>شماره حساب</th>
+                            <th>کاربر</th>
                             <th>اقدام</th>
                         </tr>
                     </thead>
@@ -29,6 +30,7 @@
                                 <td>{{ $loop->iteration }}</td>
                                 <td>{{ $counterParty->name }}</td>
                                 <td>{{ $counterParty->account_number }}</td>
+                                <td>{{ $counterParty->user?->name ?? '-' }}</td>
                                 <td>
                                     <form action="{{ route('simpleWorkflowReport.counter-party.destroy', $counterParty->id) }}" method="POST">
                                         @csrf

--- a/packages/behin-simple-workflow/src/Models/Entities/Counter_parties.php
+++ b/packages/behin-simple-workflow/src/Models/Entities/Counter_parties.php
@@ -1,24 +1,35 @@
-<?php 
-namespace Behin\SimpleWorkflow\Models\Entities; 
-use Behin\SimpleWorkflow\Controllers\Core\VariableController;
-use Illuminate\Database\Eloquent\Factories\HasFactory;
-use Illuminate\Database\Eloquent\Model;
-use Illuminate\Support\Str;
-use Illuminate\Database\Eloquent\SoftDeletes;
-use Behin\SimpleWorkflow\Models\Core\Process;
- class Counter_parties extends Model 
-{ 
-    use SoftDeletes; 
-    public $incrementing = false; 
-    protected $keyType = 'string'; 
-    public $table = 'wf_entity_counter_parties'; 
-    protected $fillable = ['name', 'account_number', 'description', 'state', ]; 
-protected static function boot()
-        {
-            parent::boot();
+<?php
 
-            static::creating(function ($model) {
-                $model->id = $model->id ?? substr(str_shuffle('ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789'), 0, 10);
-            });
-        }
+namespace Behin\SimpleWorkflow\Models\Entities;
+
+use BehinUserRoles\Models\User;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+class Counter_parties extends Model
+{
+    use SoftDeletes;
+
+    public $incrementing = false;
+
+    protected $keyType = 'string';
+
+    public $table = 'wf_entity_counter_parties';
+
+    protected $fillable = ['name', 'account_number', 'description', 'state', 'user_id'];
+
+    protected static function boot()
+    {
+        parent::boot();
+
+        static::creating(function ($model) {
+            $model->id = $model->id
+                ?? substr(str_shuffle('ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789'), 0, 10);
+        });
+    }
+
+    public function user()
+    {
+        return $this->belongsTo(User::class, 'user_id');
+    }
 }

--- a/packages/behin-user-roles/src/Models/User.php
+++ b/packages/behin-user-roles/src/Models/User.php
@@ -2,6 +2,7 @@
 
 namespace BehinUserRoles\Models;
 
+use Behin\SimpleWorkflow\Models\Entities\Counter_parties;
 use BehinInit\App\Http\Controllers\AccessController;
 use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
@@ -91,6 +92,11 @@ class User extends Authenticatable
 
     function departments(){
         return UserDepartment::where('user_id', $this->id)->get();
+    }
+
+    public function counterParties()
+    {
+        return $this->hasMany(Counter_parties::class, 'user_id');
     }
 
 }

--- a/packages/behin-user-roles/src/Views/user/edit.blade.php
+++ b/packages/behin-user-roles/src/Views/user/edit.blade.php
@@ -135,6 +135,52 @@
             </form>
         </div>
         <div class="card p-2">
+            @php
+                $selectedCounterParties = old('counterparty_ids', $user->counterParties->pluck('id')->toArray());
+            @endphp
+            <form method="post" action="{{ route('user.updateCounterParties', ['id' => $user->id]) }}">
+                @csrf
+                <div class="form-group">
+                    <label for="counterparty_ids">طرف حساب های مرتبط</label>
+                    <select class="form-control" name="counterparty_ids[]" id="counterparty_ids" multiple size="8">
+                        @foreach ($counterParties as $counterParty)
+                            @php
+                                $isSelected = in_array($counterParty->id, $selectedCounterParties, true);
+                                $assignedToOtherUser = $counterParty->user && $counterParty->user->id !== $user->id;
+                            @endphp
+                            <option value="{{ $counterParty->id }}" {{ $isSelected ? 'selected' : '' }}>
+                                {{ $counterParty->name }} - {{ $counterParty->account_number ?? 'بدون شماره حساب' }}
+                                @if ($assignedToOtherUser)
+                                    (اختصاص یافته به {{ $counterParty->user->name }})
+                                @endif
+                            </option>
+                        @endforeach
+                    </select>
+                    @error('counterparty_ids')
+                        <span class="text-danger d-block">{{ $message }}</span>
+                    @enderror
+                    @error('counterparty_ids.*')
+                        <span class="text-danger d-block">{{ $message }}</span>
+                    @enderror
+                    <small class="form-text text-muted">برای انتخاب چند گزینه از کلیدهای Ctrl یا Shift استفاده کنید.</small>
+                </div>
+                <button class="btn btn-outline-primary" type="submit">ثبت طرف حساب ها</button>
+            </form>
+            <div class="mt-3">
+                <h5>طرف حساب های کاربر</h5>
+                <ul class="list-group">
+                    @forelse ($user->counterParties as $counterParty)
+                        <li class="list-group-item d-flex justify-content-between align-items-center">
+                            <span>{{ $counterParty->name }}</span>
+                            <span class="badge badge-primary badge-pill" dir="ltr">{{ $counterParty->account_number ?? '-' }}</span>
+                        </li>
+                    @empty
+                        <li class="list-group-item text-muted">طرف حسابی برای این کاربر تعریف نشده است.</li>
+                    @endforelse
+                </ul>
+            </div>
+        </div>
+        <div class="card p-2">
             <div class="card-body row">
                 <form action="{{ route('user.disable', $user->id) }}" class="col-sm-4" method="POST" onsubmit="return confirm('آیا مطمئن هستید که می‌خواهید کاربر را از همه دستگاه‌ها خارج کنید؟');">
                     @csrf

--- a/packages/behin-user-roles/src/routes.php
+++ b/packages/behin-user-roles/src/routes.php
@@ -32,6 +32,7 @@ Route::prefix('/user')->middleware(['web', 'auth',Access::class])->group(functio
     Route::post('/{id}/change-ip', [UserController::class, 'ChangeIp'])->name('change-user-ip');
 
     Route::post('/{id}/changeShowInReport', [UserController::class, 'changeShowInReport']);
+    Route::post('/{id}/counter-parties', [UserController::class, 'updateCounterParties'])->name('user.updateCounterParties');
     Route::post('/{id}/addToDepartment', [UserController::class, 'addToDepartment'])->name('user.addToDepartment');
     Route::delete('/{user}/destroy', [UserController::class, 'destroy'])->name('user.destroy');
     Route::delete('/{id}/removeFromDepartment', [UserController::class, 'removeFromDepartment'])->name('user.removeFromDepartment');


### PR DESCRIPTION
## Summary
- add a nullable `user_id` column to the counter party entity table to persist user assignments
- expose the user–counter party relationship in the models and user management controller so admins can sync accounts per user
- extend the counter party admin UI to set the related user on creation and display the current owner in the listing

## Testing
- php -l packages/behin-simple-workflow/src/Models/Entities/Counter_parties.php
- php -l packages/behin-user-roles/src/Controllers/UserController.php
- php -l packages/behin-simple-workflow-report/src/Controllers/Core/CounterPartyController.php

------
https://chatgpt.com/codex/tasks/task_e_68e2a7c0fdcc8332aa3b4cdd925176e3