### PR TITLE
Add editing for workflow report counter parties

### DIFF
--- a/packages/behin-simple-workflow-report/src/Controllers/Core/CounterPartyController.php
+++ b/packages/behin-simple-workflow-report/src/Controllers/Core/CounterPartyController.php
@@ -50,6 +50,14 @@ class CounterPartyController extends Controller
         return view('SimpleWorkflowReportView::Core.CounterParty.create', compact('users'));
     }
 
+    public function edit(string $counterParty)
+    {
+        $counterParty = Counter_parties::findOrFail($counterParty);
+        $users = User::orderBy('name')->get();
+
+        return view('SimpleWorkflowReportView::Core.CounterParty.edit', compact('counterParty', 'users'));
+    }
+
     public function store(Request $request)
     {
         $validated = $request->validate([
@@ -61,6 +69,23 @@ class CounterPartyController extends Controller
         ]);
 
         Counter_parties::create($validated);
+        return redirect()->route('simpleWorkflowReport.counter-party.index');
+    }
+
+    public function update(Request $request, string $counterParty)
+    {
+        $counterParty = Counter_parties::findOrFail($counterParty);
+
+        $validated = $request->validate([
+            'name' => ['required', 'string', 'max:255'],
+            'account_number' => ['nullable', 'string', 'max:255'],
+            'user_id' => ['nullable', 'integer', 'exists:users,id'],
+            'description' => ['nullable', 'string'],
+            'state' => ['nullable', 'string', 'max:255'],
+        ]);
+
+        $counterParty->update($validated);
+
         return redirect()->route('simpleWorkflowReport.counter-party.index');
     }
 

--- a/packages/behin-simple-workflow-report/src/Views/Core/CounterParty/edit.blade.php
+++ b/packages/behin-simple-workflow-report/src/Views/Core/CounterParty/edit.blade.php
@@ -1,0 +1,63 @@
+@extends('behin-layouts.app')
+
+@section('content')
+    <div class="container">
+        <div class="card">
+            <div class="card-header">ویرایش طرف حساب</div>
+            <div class="card-body">
+                <form action="{{ route('simpleWorkflowReport.counter-party.update', $counterParty->id) }}" method="POST">
+                    @csrf
+                    @method('PUT')
+                    <div class="row">
+                        <div class="col-md-4">
+                            <div class="form-group">
+                                <label for="name">نام</label>
+                                <input type="text" name="name" id="name" class="form-control"
+                                    value="{{ old('name', $counterParty->name) }}" autofocus>
+                                @error('name')
+                                    <span class="text-danger">{{ $message }}</span>
+                                @enderror
+                            </div>
+                        </div>
+                        <div class="col-md-4">
+                            <div class="form-group">
+                                <label for="account_number">شماره حساب</label>
+                                <input type="text" name="account_number" id="account_number" class="form-control"
+                                    value="{{ old('account_number', $counterParty->account_number) }}">
+                                @error('account_number')
+                                    <span class="text-danger">{{ $message }}</span>
+                                @enderror
+                            </div>
+                        </div>
+                        <div class="col-md-4">
+                            <div class="form-group">
+                                <label for="user_id">کاربر مرتبط</label>
+                                <select name="user_id" id="user_id" class="form-control">
+                                    <option value="">-</option>
+                                    @foreach ($users as $user)
+                                        <option value="{{ $user->id }}"
+                                            {{ old('user_id', $counterParty->user_id) == $user->id ? 'selected' : '' }}>
+                                            {{ $user->name }} ({{ $user->email }})
+                                        </option>
+                                    @endforeach
+                                </select>
+                                @error('user_id')
+                                    <span class="text-danger">{{ $message }}</span>
+                                @enderror
+                            </div>
+                        </div>
+                    </div>
+                    <div class="form-group">
+                        <label for="description">توضیحات</label>
+                        <textarea name="description" id="description" class="form-control" rows="3">{{ old('description', $counterParty->description) }}</textarea>
+                        @error('description')
+                            <span class="text-danger">{{ $message }}</span>
+                        @enderror
+                    </div>
+                    <button type="submit" class="btn btn-primary">ذخیره</button>
+                    <a href="{{ route('simpleWorkflowReport.counter-party.index') }}" class="btn btn-secondary">بازگشت</a>
+                </form>
+            </div>
+        </div>
+    </div>
+@endsection

--- a/packages/behin-simple-workflow-report/src/Views/Core/CounterParty/index.blade.php
+++ b/packages/behin-simple-workflow-report/src/Views/Core/CounterParty/index.blade.php
@@ -31,7 +31,9 @@
                                 <td>{{ $counterParty->name }}</td>
                                 <td>{{ $counterParty->account_number }}</td>
                                 <td>{{ $counterParty->user?->name ?? '-' }}</td>
-                                <td>
+                                <td class="d-flex gap-1">
+                                    <a href="{{ route('simpleWorkflowReport.counter-party.edit', $counterParty->id) }}"
+                                        class="btn btn-info btn-sm"><i class="fa fa-edit"></i></a>
                                     <form action="{{ route('simpleWorkflowReport.counter-party.destroy', $counterParty->id) }}" method="POST">
                                         @csrf
                                         @method('DELETE')


### PR DESCRIPTION
## Summary
- add edit and update handling to the workflow report counter party controller
- provide an edit blade for counter party records with existing data pre-filled
- expose an edit button in the counter party list for quick access

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e2b27814fc8332bf2d0e11c74104d2